### PR TITLE
feat(http-language): basics of the http language file format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +259,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curlz"
 version = "0.1.0-alpha.3"
 dependencies = [
@@ -263,11 +301,15 @@ dependencies = [
  "dotenvy",
  "env_logger",
  "filenamify",
+ "indoc",
  "insta",
  "jsonwebtoken",
  "log",
  "minijinja",
+ "pest",
+ "pest_derive",
  "predicates",
+ "pretty_assertions",
  "rstest",
  "serde",
  "serde_json",
@@ -352,10 +394,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "doc-comment"
@@ -553,6 +611,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +799,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
 name = "infer"
@@ -920,6 +994,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +1022,50 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -986,6 +1113,18 @@ checksum = "ad3f7fa8d61e139cbc7c3edfebf3b6678883a53f5ffac65d1259329a93ee43a5"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
 ]
 
 [[package]]
@@ -1254,6 +1393,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1637,18 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"
@@ -1770,6 +1932,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba45b8163c49ab5f972e59a8a5a03b6d2972619d486e19ec9fe744f7c2753d3c"
+checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
  "once_cell",
@@ -130,21 +130,15 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -154,9 +148,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -222,11 +216,11 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
 dependencies = [
- "cache-padded",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -265,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -321,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -333,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -348,15 +351,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,9 +410,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -734,9 +737,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -792,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -814,9 +817,9 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "insta"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581d4e3314cae4536e5d22ffd23189d4a374696c5ef733eadafae0ed273fd303"
+checksum = "e48b08a091dfe5b09a6a9688c468fdd5b4396e92ce09e2eb932f0884b02788a4"
 dependencies = [
  "console",
  "lazy_static",
@@ -860,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
+checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
  "base64",
  "pem",
@@ -880,9 +883,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "link-cplusplus"
@@ -989,9 +992,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "output_vt100"
@@ -1025,9 +1028,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1035,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1045,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1058,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
  "once_cell",
  "pest",
@@ -1087,9 +1090,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.2"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab68289ded120dcbf9d571afcf70163233229052aec9b08ab09532f698d0e1e6"
+checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -1101,15 +1104,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7125585d872860e9955ca571650b27a4979c5823084168c5ed5bbfb016b56"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3f7fa8d61e139cbc7c3edfebf3b6678883a53f5ffac65d1259329a93ee43a5"
+checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1326,18 +1329,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1346,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1405,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "simple_asn1"
@@ -1448,9 +1451,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1566,9 +1569,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1578,14 +1581,14 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,9 +1643,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "assert-json-diff"
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -78,7 +78,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -225,16 +225,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -324,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -336,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -351,15 +350,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,6 +674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
 
 [[package]]
 name = "infer"
@@ -817,9 +825,9 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "insta"
-version = "1.23.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48b08a091dfe5b09a6a9688c468fdd5b4396e92ce09e2eb932f0884b02788a4"
+checksum = "f6f0f08b46e4379744de2ab67aa8f7de3ffd1da3e275adc41fcc82053ede46ff"
 dependencies = [
  "console",
  "lazy_static",
@@ -848,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -883,15 +891,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -976,19 +984,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "os_str_bytes"
@@ -1028,9 +1036,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1038,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1048,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1061,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
@@ -1090,9 +1098,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -1156,18 +1164,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1311,36 +1319,36 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1349,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1384,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.14"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
+checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1451,9 +1459,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1484,16 +1492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,18 +1505,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1569,9 +1567,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1637,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -1661,9 +1659,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -1688,9 +1686,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"
@@ -1907,9 +1905,9 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "wiremock"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249dc68542861d17eae4b4e5e8fb381c2f9e8f255a84f6771d5fdf8b6c03ce3c"
+checksum = "631cafe37a030d8453218cf7c650abcc359be8fba4a2fbc5c27fdb9728635406"
 dependencies = [
  "assert-json-diff",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1297,15 +1297,16 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ pest = "2.4"
 pest_derive = "2.4"
 
 [dev-dependencies]
-insta = "1.17"
+insta = "1"
 tempfile = "3.3"
 assert_cmd = "2.0"
 predicates = "2.1"
-rstest = "0.15"
+rstest = "0.16"
 wiremock = "0.5"
-tokio = { version = "1.21", features = ["rt", "macros"], default-features = false }
-indoc = "1.0"
-pretty_assertions = "1.3"
+tokio = { version = "1", features = ["rt", "macros"], default-features = false }
+indoc = "1"
+pretty_assertions = "1"
 
 [[bin]]
 name = "curlz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ minijinja = "0.25"
 jsonwebtoken = "8.1"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
+## experimental
+pest = "2.4"
+pest_derive = "2.4"
+
 [dev-dependencies]
 insta = "1.17"
 tempfile = "3.3"
@@ -34,6 +38,8 @@ predicates = "2.1"
 rstest = "0.15"
 wiremock = "0.5"
 tokio = { version = "1.21", features = ["rt", "macros"], default-features = false }
+indoc = "1.0"
+pretty_assertions = "1.3"
 
 [[bin]]
 name = "curlz"

--- a/README.md
+++ b/README.md
@@ -32,22 +32,25 @@
   - ☑️prompt for interactive input with a label as `{{ prompt_for("Username") }}` or `{{ prompt_for("Birthdate") }}`
     `curlz -- -u "{{ prompt_for("Username") }}:{{ prompt_password() }}" https://api.github.com/user`
 - ☑️evaluate placeholders at the beginning of an url like:
-  ```sh
-  curlz r --define 'host=https://httpbin.org' '{{host}}/get?show_env={{ prompt_for("show_env") }}'
-  ```
+```sh
+curlz r --define 'host=https://httpbin.org' '{{host}}/get?show_env={{ prompt_for("show_env") }}'
+```
 - ☑️special placeholder for developers, like for Json Web Tokens (JWT)
-  - example: `{{ jwt(claims, signing_key) }}`, where `claims` and `signing_key` are looked up at the environment file or can be directly provided map and string
-    ```sh
-    curlz r -H 'Authorization: Bearer {{ jwt({"uid": "1234"}, "000") }}' https://httpbin.org/bearer -- -vvv
-    ```
-- [ ]: send json payload and json headers with the `--json` argument
-  - example: 
-    ```sh
-    curlz r --json -d '{ "foo": "bar" }' -X POST 'https://httpbin.org/anything'`
-    ```
+  example: `{{ jwt(claims, signing_key) }}`, where `claims` and `signing_key` are looked up at the environment file or can be directly provided map and string
+```sh
+curlz r -H 'Authorization: Bearer {{ jwt({"uid": "1234"}, "000") }}' https://httpbin.org/bearer -- -vvv
+```
+- ☑️send a http body via `-d | --data` 
+```sh
+curlz r -d 'Hello World' -X POST 'https://httpbin.org/anything'
+```
+- ☑️send a json payload and headers with the `--json` argument
+```sh
+curlz r --json -d '{ "foo": "bar" }' -X POST 'https://httpbin.org/anything'
+```
 
-## TODOs
-- [ ] support rest client template language [see #5](https://github.com/curlz-rs/curlz/issues/5)
+## WIP
+- [⏳] support rest client template language [see #5](https://github.com/curlz-rs/curlz/issues/5)
 
 ## Example #1
 
@@ -65,7 +68,7 @@ In this example we're going to download a pre-configured `.gitignore` for a give
   ```
 - Finally, we can keep using the bookmark from now on: `curlz r gitignore`
 
-## Template functions
+## Template function documentation
 
 ### Json Web Token - `jwt(claims: map, [signing_key: string])`
 - arguments:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@
     ```sh
     curlz r -H 'Authorization: Bearer {{ jwt({"uid": "1234"}, "000") }}' https://httpbin.org/bearer -- -vvv
     ```
+- [ ]: send json payload and json headers with the `--json` argument
+  - example: 
+    ```sh
+    curlz r --json -d '{ "foo": "bar" }' -X POST 'https://httpbin.org/anything'`
+    ```
 
 ## TODOs
 - [ ] support rest client template language [see #5](https://github.com/curlz-rs/curlz/issues/5)

--- a/src/curlz/cli/commands/request.rs
+++ b/src/curlz/cli/commands/request.rs
@@ -1,4 +1,4 @@
-use crate::data::{HttpHeaders, HttpMethod, HttpRequest, HttpUri};
+use crate::data::{HttpBody, HttpHeaders, HttpMethod, HttpRequest, HttpUri};
 use crate::interactive;
 use crate::ops::{
     LoadBookmark, MutOperation, Operation, OperationContext, RunCurlCommand, SaveBookmark,
@@ -103,6 +103,7 @@ impl MutOperation for RequestCli {
                     method,
                     version: Http11,
                     headers,
+                    body: HttpBody::default(),
                     placeholders,
                     // todo: implement placeholder scanning..
                     curl_params: raw,
@@ -127,6 +128,7 @@ impl MutOperation for RequestCli {
                     method,
                     version: Http11,
                     headers,
+                    body: HttpBody::default(),
                     placeholders,
                     // todo: implement placeholder scanning..
                     curl_params: raw,

--- a/src/curlz/cli/commands/request.rs
+++ b/src/curlz/cli/commands/request.rs
@@ -7,6 +7,7 @@ use crate::utils::parse_pairs;
 use crate::variables::Placeholder;
 
 use crate::cli::HeaderArgs;
+use crate::data::HttpVersion::Http11;
 use anyhow::Context;
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -100,6 +101,7 @@ impl MutOperation for RequestCli {
                     // todo: also replace placeholders in there..
                     url: bookmark_or_url.to_string(),
                     method,
+                    version: Http11,
                     headers,
                     placeholders,
                     // todo: implement placeholder scanning..
@@ -123,6 +125,7 @@ impl MutOperation for RequestCli {
                 .map(|url| HttpRequest {
                     url,
                     method,
+                    version: Http11,
                     headers,
                     placeholders,
                     // todo: implement placeholder scanning..

--- a/src/curlz/data/bookmark.rs
+++ b/src/curlz/data/bookmark.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 use crate::data::HttpRequest;
 use crate::ops::SaveBookmark;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Bookmark {
-    slug: String,
-    request: HttpRequest,
+    pub slug: String,
+    pub request: HttpRequest,
 }
 
 impl AsRef<HttpRequest> for Bookmark {

--- a/src/curlz/data/request/http_body.rs
+++ b/src/curlz/data/request/http_body.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub enum HttpBody {
+    InlineText(String),
+    InlineBinary(Vec<u8>),
+    Extern(PathBuf),
+    None,
+}
+
+impl Default for HttpBody {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl HttpBody {
+    pub fn contents(&self) -> std::io::Result<Option<String>> {
+        Ok(match self {
+            HttpBody::InlineText(c) => Some(c.to_owned()),
+            HttpBody::InlineBinary(_) => todo!("Binary data cannot be represented as string yet"),
+            HttpBody::Extern(f) => Some(std::fs::read_to_string(f)?),
+            HttpBody::None => None,
+        })
+    }
+}

--- a/src/curlz/data/request/http_body.rs
+++ b/src/curlz/data/request/http_body.rs
@@ -17,12 +17,29 @@ impl Default for HttpBody {
 }
 
 impl HttpBody {
+    // todo: not in sync with `.as_bytes()`
     pub fn contents(&self) -> std::io::Result<Option<String>> {
         Ok(match self {
             HttpBody::InlineText(c) => Some(c.to_owned()),
             HttpBody::InlineBinary(_) => todo!("Binary data cannot be represented as string yet"),
             HttpBody::Extern(f) => Some(std::fs::read_to_string(f)?),
             HttpBody::None => None,
+        })
+    }
+
+    // todo: not in sync with `.contents()`
+    pub fn as_bytes(&self) -> std::io::Result<&[u8]> {
+        Ok(match self {
+            HttpBody::InlineText(t) => t.as_bytes(),
+            HttpBody::InlineBinary(b) => b.as_slice(),
+            HttpBody::Extern(_) => todo!("not yet there.."),
+            // HttpBody::Extern(e) => {
+            //     let mut f = fs::File::open(e).unwrap();
+            //     let mut data = Vec::new();
+            //     f.read_to_end(&mut data).unwrap();
+            //     data.as_slice()
+            // }
+            HttpBody::None => b"",
         })
     }
 }

--- a/src/curlz/data/request/http_headers.rs
+++ b/src/curlz/data/request/http_headers.rs
@@ -1,7 +1,7 @@
 use crate::cli::HeaderArgs;
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HttpHeaders(Vec<(String, String)>);
 
 impl HttpHeaders {

--- a/src/curlz/data/request/http_request.rs
+++ b/src/curlz/data/request/http_request.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::data::{HttpHeaders, HttpMethod, HttpVersion};
+use crate::data::{HttpHeaders, HttpMethod, HttpUri, HttpVersion};
 use crate::variables::Placeholder;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HttpRequest {
-    pub url: String,
+    pub url: HttpUri,
     pub method: HttpMethod,
     pub version: HttpVersion,
     pub headers: HttpHeaders,

--- a/src/curlz/data/request/http_request.rs
+++ b/src/curlz/data/request/http_request.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::data::{HttpHeaders, HttpMethod};
+use crate::data::{HttpHeaders, HttpMethod, HttpVersion};
 use crate::variables::Placeholder;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HttpRequest {
     pub url: String,
     pub method: HttpMethod,
+    pub version: HttpVersion,
     pub headers: HttpHeaders,
     pub curl_params: Vec<String>,
     pub placeholders: Vec<Placeholder>,

--- a/src/curlz/data/request/http_request.rs
+++ b/src/curlz/data/request/http_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::data::{HttpHeaders, HttpMethod, HttpUri, HttpVersion};
+use crate::data::{HttpBody, HttpHeaders, HttpMethod, HttpUri, HttpVersion};
 use crate::variables::Placeholder;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -9,6 +9,7 @@ pub struct HttpRequest {
     pub method: HttpMethod,
     pub version: HttpVersion,
     pub headers: HttpHeaders,
+    pub body: HttpBody,
     pub curl_params: Vec<String>,
     pub placeholders: Vec<Placeholder>,
 }

--- a/src/curlz/data/request/http_uri.rs
+++ b/src/curlz/data/request/http_uri.rs
@@ -1,0 +1,31 @@
+//! # HTTP URI
+//! Describes a HTTP URI with template variables or functions contained
+//!
+//! ## not yet implemented:
+//! - [ ] TODO: impl validation for URIs with placeholders
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct HttpUri(String);
+
+impl AsRef<str> for HttpUri {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl From<&str> for HttpUri {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl TryFrom<String> for HttpUri {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        // todo: validation might go here
+        Ok(Self(value))
+    }
+}

--- a/src/curlz/data/request/http_version.rs
+++ b/src/curlz/data/request/http_version.rs
@@ -1,0 +1,61 @@
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpVersion {
+    #[serde(rename = "HTTP/1.1")]
+    Http11,
+    #[serde(rename = "HTTP/2")]
+    Http2,
+    #[serde(rename = "HTTP/3")]
+    Http3,
+}
+
+impl From<&HttpVersion> for String {
+    fn from(version: &HttpVersion) -> Self {
+        serde_yaml::to_string(version)
+            .unwrap()
+            .trim_end()
+            .to_string()
+    }
+}
+
+impl FromStr for HttpVersion {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_yaml::from_str(s.to_uppercase().as_str())
+            .map_err(|_| anyhow!("Unsupported HTTP version: {}", s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_str_to_http_method_gracefully() {
+        assert_eq!(
+            "HTTP/1.1".parse::<HttpVersion>().unwrap(),
+            HttpVersion::Http11
+        );
+        assert_eq!(
+            "http/1.1".parse::<HttpVersion>().unwrap(),
+            HttpVersion::Http11
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported HTTP version: HTTP/1.0")]
+    fn should_throw_unsupported_methods() {
+        "HTTP/1.0".parse::<HttpVersion>().unwrap();
+    }
+
+    #[test]
+    fn should_convert_to_uppercase_string() {
+        let version: String = (&HttpVersion::Http11).into();
+        assert_eq!(version, "HTTP/1.1");
+    }
+}

--- a/src/curlz/data/request/mod.rs
+++ b/src/curlz/data/request/mod.rs
@@ -1,9 +1,11 @@
+mod http_body;
 mod http_headers;
 mod http_method;
 mod http_request;
 mod http_uri;
 mod http_version;
 
+pub use http_body::*;
 pub use http_headers::*;
 pub use http_method::*;
 pub use http_request::*;

--- a/src/curlz/data/request/mod.rs
+++ b/src/curlz/data/request/mod.rs
@@ -1,9 +1,11 @@
 mod http_headers;
 mod http_method;
 mod http_request;
+mod http_uri;
 mod http_version;
 
 pub use http_headers::*;
 pub use http_method::*;
 pub use http_request::*;
+pub use http_uri::*;
 pub use http_version::*;

--- a/src/curlz/data/request/mod.rs
+++ b/src/curlz/data/request/mod.rs
@@ -1,7 +1,9 @@
 mod http_headers;
 mod http_method;
 mod http_request;
+mod http_version;
 
 pub use http_headers::*;
 pub use http_method::*;
 pub use http_request::*;
+pub use http_version::*;

--- a/src/curlz/http.rs
+++ b/src/curlz/http.rs
@@ -1,5 +1,5 @@
 //! a module for experimenting with the http language that the rest client uses
-use crate::data::{Bookmark, HttpHeaders, HttpMethod, HttpRequest, HttpVersion};
+use crate::data::{Bookmark, HttpHeaders, HttpMethod, HttpRequest, HttpUri, HttpVersion};
 use anyhow::anyhow;
 use pest::iterators::Pair;
 use pest::Parser;
@@ -71,7 +71,7 @@ impl TryFrom<Pair<'_, Rule>> for HttpRequest {
             Rule::request => {
                 let mut inner_rules = request.into_inner();
                 let method: HttpMethod = inner_rules.next().unwrap().try_into()?;
-                let url = inner_rules.next().unwrap().as_str().to_string();
+                let url: HttpUri = inner_rules.next().unwrap().try_into()?;
                 let version: HttpVersion = inner_rules.next().unwrap().try_into()?;
                 let headers = inner_rules
                     .next()
@@ -94,6 +94,17 @@ impl TryFrom<Pair<'_, Rule>> for HttpRequest {
                 })
             }
             _ => Err(anyhow!("The parsing result is not a valid `request`")),
+        }
+    }
+}
+
+impl TryFrom<Pair<'_, Rule>> for HttpUri {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Pair<'_, Rule>) -> Result<Self, Self::Error> {
+        match value.as_rule() {
+            Rule::uri => value.as_str().to_string().try_into(),
+            _ => Err(anyhow!("The parsing result is not a valid `uri`")),
         }
     }
 }

--- a/src/curlz/http.rs
+++ b/src/curlz/http.rs
@@ -1,0 +1,202 @@
+//! a module for experimenting with the http language that the rest client uses
+use crate::data::{Bookmark, HttpHeaders, HttpMethod, HttpRequest, HttpVersion};
+use anyhow::anyhow;
+use pest::iterators::Pair;
+use pest::Parser;
+
+#[derive(Parser)]
+#[grammar = "parser/http-grammar.pest"] // relative to project `src`
+struct HttpParser;
+
+#[allow(dead_code)]
+fn parse_request_file(req_file: impl AsRef<str>) -> Vec<Bookmark> {
+    let mut requests = vec![];
+
+    let req_file = req_file.as_ref();
+    let file = HttpParser::parse(Rule::file, req_file)
+        .expect("parsing failed!")
+        .next()
+        .unwrap();
+
+    let mut slug: String = "".to_owned();
+    for line in file.into_inner() {
+        match line.as_rule() {
+            Rule::request => {
+                requests.push(Bookmark {
+                    slug: slug.to_owned(),
+                    request: HttpRequest::from(line),
+                });
+            }
+            Rule::delimiter => {
+                slug = line.as_str().trim().to_owned();
+                println!("delimiter = {:?}", line.as_str());
+            }
+            x => {
+                println!("x = {:?}\n", x);
+            }
+        }
+    }
+
+    requests
+}
+
+/// todo: write tests
+impl From<Pair<'_, Rule>> for HttpHeaders {
+    fn from(headers: Pair<'_, Rule>) -> Self {
+        match headers.as_rule() {
+            Rule::headers => {
+                let mut h: HttpHeaders = Default::default();
+                for header in headers.into_inner() {
+                    let mut inner_rules = header.into_inner();
+
+                    let name: &str = inner_rules.next().unwrap().as_str();
+                    let value: &str = inner_rules.next().unwrap().as_str();
+
+                    h.push(name, value);
+                }
+                h
+            }
+            _ => unreachable!("this should not happen"),
+        }
+    }
+}
+
+/// todo: write tests
+impl From<Pair<'_, Rule>> for HttpRequest {
+    fn from(request: Pair<'_, Rule>) -> Self {
+        match request.as_rule() {
+            Rule::request => {
+                let mut inner_rules = request.into_inner();
+                let method: HttpMethod = inner_rules
+                    .next()
+                    .unwrap()
+                    .as_str()
+                    .parse::<HttpMethod>()
+                    .unwrap();
+                let url = inner_rules.next().unwrap().as_str().to_string();
+                let version: HttpVersion = inner_rules.next().unwrap().try_into().unwrap();
+                let headers = inner_rules.next();
+
+                dbg!(&method);
+                dbg!(&url);
+                dbg!(&version);
+                // dbg!(body);
+
+                Self {
+                    url,
+                    method,
+                    version,
+                    headers: headers.map(HttpHeaders::from).unwrap_or_default(),
+                    curl_params: Default::default(),
+                    placeholders: Default::default(),
+                }
+            }
+            _ => {
+                unreachable!("the client code ensures this cannot happen!")
+            }
+        }
+    }
+}
+
+/// converts `Pairs` into [`HttpVersion`]
+impl TryFrom<Pair<'_, Rule>> for HttpVersion {
+    type Error = anyhow::Error;
+    fn try_from(value: Pair<'_, Rule>) -> Result<Self, Self::Error> {
+        match value.as_rule() {
+            Rule::version => value.as_str().parse::<HttpVersion>(),
+            _ => Err(anyhow!("The parsing result is not a valid `version`")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::*;
+
+    use crate::data::HttpVersion::Http11;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        indoc! {r#"
+            ### GET gitignore template for rustlang 
+            GET https://api.github.com/gitignore/templates/Rust HTTP/1.1
+            Accept: application/json
+        "#},
+        Bookmark {
+            slug: "### GET gitignore template for rustlang".into(),
+            request: HttpRequest {
+                url: "https://api.github.com/gitignore/templates/Rust".into(),
+                method: HttpMethod::Get,
+                version: HttpVersion::Http11,
+                headers: HttpHeaders::from(["Accept: application/json".to_owned()].as_slice()),
+                curl_params: Default::default(),
+                placeholders: Default::default(),
+            }
+        }
+    )]
+    #[case(
+        indoc! {r#"
+            ### GET request with environment variables
+            GET https://api.github.com/gitignore/templates/Rust HTTP/1.1
+        "#},
+        Bookmark {
+            slug: "### GET request with environment variables".into(),
+            request: HttpRequest {
+                url: "https://api.github.com/gitignore/templates/Rust".into(),
+                method: HttpMethod::Get,
+                version: HttpVersion::Http11,
+                headers: Default::default(),
+                curl_params: Default::default(),
+                placeholders: Default::default(),
+            }
+        }
+    )]
+    fn should_parse_a_http_message(
+        #[case] request_file_contents: &str,
+        #[case] expected: Bookmark,
+    ) {
+        assert_eq!(
+            parse_request_file(request_file_contents).pop().unwrap(),
+            expected
+        );
+    }
+
+    mod http_version {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn test_http_version_parsing() {
+            let version = HttpParser::parse(Rule::version, "HTTP/1.1")
+                .expect("parsing failed!")
+                .next()
+                .unwrap();
+            let version: HttpVersion = version.try_into().unwrap();
+            assert_eq!(version, Http11);
+        }
+
+        #[test]
+        #[should_panic(expected = "Unsupported HTTP version: HTTP/1.0")]
+        fn test_http_version_parsing_unsupported_version() {
+            let _: HttpVersion = HttpParser::parse(Rule::version, "HTTP/1.0")
+                .unwrap()
+                .next()
+                .unwrap()
+                .try_into()
+                .unwrap();
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_http_version_parsing_parsing_error() {
+            HttpParser::parse(Rule::version, "http/")
+                .unwrap()
+                .next()
+                .unwrap();
+        }
+    }
+}

--- a/src/curlz/lib.rs
+++ b/src/curlz/lib.rs
@@ -7,7 +7,7 @@ pub mod utils;
 pub mod variables;
 pub mod workspace;
 
-mod http;
+mod http_file;
 #[cfg(test)]
 pub mod test_utils;
 

--- a/src/curlz/lib.rs
+++ b/src/curlz/lib.rs
@@ -7,7 +7,11 @@ pub mod utils;
 pub mod variables;
 pub mod workspace;
 
+mod http;
 #[cfg(test)]
 pub mod test_utils;
+
+#[macro_use]
+extern crate pest_derive;
 
 pub type Result<T> = anyhow::Result<T>;

--- a/src/curlz/variables.rs
+++ b/src/curlz/variables.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Placeholder {
     pub name: String,
     pub value: Option<String>,

--- a/src/curlz/workspace/bookmark_collection.rs
+++ b/src/curlz/workspace/bookmark_collection.rs
@@ -64,8 +64,8 @@ impl BookmarkCollection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::HttpMethod;
     use crate::data::HttpVersion::Http11;
+    use crate::data::{HttpBody, HttpMethod};
     use crate::data::{HttpHeaders, HttpRequest};
     use crate::ops::SaveBookmark;
     use crate::variables::Placeholder;
@@ -90,6 +90,7 @@ mod tests {
             method: HttpMethod::Get,
             version: Http11,
             headers: HttpHeaders::default(),
+            body: HttpBody::default(),
             curl_params: vec![],
             placeholders: vec![email_placeholder(), protonmail_api_baseurl_placeholder()],
         };

--- a/src/curlz/workspace/bookmark_collection.rs
+++ b/src/curlz/workspace/bookmark_collection.rs
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn should_handle_save_bookmark_command() {
         let request = HttpRequest {
-            url: "{{protonmail_api_baseurl}}/pks/lookup?op=get&search={{email}}".to_owned(),
+            url: "{{protonmail_api_baseurl}}/pks/lookup?op=get&search={{email}}".into(),
             method: HttpMethod::Get,
             version: Http11,
             headers: HttpHeaders::default(),

--- a/src/curlz/workspace/bookmark_collection.rs
+++ b/src/curlz/workspace/bookmark_collection.rs
@@ -65,6 +65,7 @@ impl BookmarkCollection {
 mod tests {
     use super::*;
     use crate::data::HttpMethod;
+    use crate::data::HttpVersion::Http11;
     use crate::data::{HttpHeaders, HttpRequest};
     use crate::ops::SaveBookmark;
     use crate::variables::Placeholder;
@@ -87,6 +88,7 @@ mod tests {
         let request = HttpRequest {
             url: "{{protonmail_api_baseurl}}/pks/lookup?op=get&search={{email}}".to_owned(),
             method: HttpMethod::Get,
+            version: Http11,
             headers: HttpHeaders::default(),
             curl_params: vec![],
             placeholders: vec![email_placeholder(), protonmail_api_baseurl_placeholder()],

--- a/src/curlz/workspace/snapshots/curlz__workspace__bookmark_collection__tests__should_handle_save_bookmark_command.snap
+++ b/src/curlz/workspace/snapshots/curlz__workspace__bookmark_collection__tests__should_handle_save_bookmark_command.snap
@@ -8,6 +8,7 @@ request:
   method: GET
   version: HTTP/1.1
   headers: []
+  body: None
   curl_params: []
   placeholders:
   - name: email

--- a/src/curlz/workspace/snapshots/curlz__workspace__bookmark_collection__tests__should_handle_save_bookmark_command.snap
+++ b/src/curlz/workspace/snapshots/curlz__workspace__bookmark_collection__tests__should_handle_save_bookmark_command.snap
@@ -6,6 +6,7 @@ slug: /protonmail/gpg/:email
 request:
   url: '{{protonmail_api_baseurl}}/pks/lookup?op=get&search={{email}}'
   method: GET
+  version: HTTP/1.1
   headers: []
   curl_params: []
   placeholders:

--- a/src/parser/http-grammar.pest
+++ b/src/parser/http-grammar.pest
@@ -1,0 +1,16 @@
+request = { request_line ~ headers? ~ (NEWLINE ~ body)? }
+request_line = _{ method ~ " "+ ~ uri ~ " "+ ~ version ~ NEWLINE }
+uri = { (!whitespace ~ ANY)+ }
+method = { "GET" | "POST" | "PUT" }
+version = { "HTTP/" ~ (ASCII_DIGIT | ".")+ }
+whitespace = _{ " " | "\t" }
+
+headers = { header+ }
+header = { header_name ~ ":" ~ whitespace ~ header_value ~ NEWLINE }
+header_name = { (!(":" | NEWLINE) ~ ANY)+ }
+header_value = { (!NEWLINE ~ ANY)+ }
+
+body = { (!delimiter ~ ANY)+ }
+delimiter = { "#"{3} ~ (!NEWLINE ~ ANY)+ ~ NEWLINE+ }
+
+file = { SOI ~ (delimiter? ~ request) ~ (delimiter ~ request)* ~ EOI}

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -1,69 +1,34 @@
-use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
-use dotenvy::dotenv;
+use curlz::data::HttpMethod;
 use predicates::prelude::*;
-use std::process::Command;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn binary() -> Result<Command, assert_cmd::cargo::CargoError> {
-    Command::cargo_bin(env!("CARGO_PKG_NAME"))
-}
+use crate::testlib::{binary, CurlzTestSuite};
+
+mod testlib;
 
 #[test]
 fn should_show_usage_when_no_args_passed() {
     binary()
-        .unwrap()
         .assert()
         .failure()
         .stderr(predicate::str::contains("USAGE:"));
 }
 
 #[tokio::test]
-async fn should_request_a_url() {
-    CurlzTest::new()
+async fn should_send_as_get() {
+    CurlzTestSuite::new()
         .await
-        .with_url("/gitignore/templates/Rust")
-        .request()
+        .send_to_path("/gitignore/templates/Rust")
+        .issue_request()
         .await;
 }
 
-struct CurlzTest {
-    mock_server: MockServer,
-    url_part: String,
-    payload: String,
-}
-
-impl CurlzTest {
-    pub async fn new() -> Self {
-        dotenv().ok();
-        Self {
-            mock_server: MockServer::start().await,
-            url_part: "".to_string(),
-            payload: "# curlz rocks".to_string(),
-        }
-    }
-
-    /// sets the target url to be requested
-    pub fn with_url(mut self, url_part: &str) -> Self {
-        self.url_part = url_part.to_string();
-        self
-    }
-
-    /// runs curlz and requests the given url
-    pub async fn request(self) -> Assert {
-        Mock::given(method("GET"))
-            .and(path(self.url_part.as_str()))
-            .respond_with(ResponseTemplate::new(200).set_body_string(&self.payload))
-            .mount(&self.mock_server)
-            .await;
-
-        let url = format!("{}{}", &self.mock_server.uri(), self.url_part);
-        binary()
-            .unwrap()
-            .args(["r", url.as_str()])
-            .assert()
-            .success()
-            .stdout(predicate::str::contains(&self.payload))
-    }
+#[tokio::test]
+async fn should_send_payload_as_post() {
+    CurlzTestSuite::new()
+        .await
+        .send_to_path("/anything")
+        .send_with_method(HttpMethod::Post)
+        .issue_request()
+        .await;
 }

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -1,5 +1,5 @@
 use assert_cmd::prelude::*;
-use curlz::data::HttpMethod;
+use curlz::data::{HttpBody, HttpMethod};
 use predicates::prelude::*;
 
 use crate::testlib::{binary, CurlzTestSuite};
@@ -18,17 +18,28 @@ fn should_show_usage_when_no_args_passed() {
 async fn should_send_as_get() {
     CurlzTestSuite::new()
         .await
-        .send_to_path("/gitignore/templates/Rust")
-        .issue_request()
+        .with_path("/gitignore/templates/Rust")
+        .send_request()
         .await;
 }
 
 #[tokio::test]
-async fn should_send_payload_as_post() {
+async fn should_send_as_post() {
     CurlzTestSuite::new()
         .await
-        .send_to_path("/anything")
-        .send_with_method(HttpMethod::Post)
-        .issue_request()
+        .with_path("/anything")
+        .with_method(HttpMethod::Post)
+        .send_request()
+        .await;
+}
+
+#[tokio::test]
+async fn should_send_text_as_put() {
+    CurlzTestSuite::new()
+        .await
+        .with_path("/anything")
+        .with_method(HttpMethod::Put)
+        .with_payload(HttpBody::InlineText("Howdy Pal!".to_string()))
+        .send_request()
         .await;
 }

--- a/tests/fixtures/send-payload-as-post.http
+++ b/tests/fixtures/send-payload-as-post.http
@@ -1,0 +1,9 @@
+### this is a POST request with a body
+POST https://httpbin.org/anything
+Accept: application/json
+Content-Type: application/json
+
+{
+    "foo": "Bar",
+    "bool": true
+}

--- a/tests/testlib.rs
+++ b/tests/testlib.rs
@@ -1,0 +1,68 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+use assert_cmd::assert::Assert;
+use dotenvy::dotenv;
+use std::process::Command;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use curlz::data::HttpMethod;
+
+pub fn binary() -> Command {
+    Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
+}
+
+pub struct CurlzTestSuite {
+    mock_server: MockServer,
+    url_part: String,
+    http_method: String,
+    payload: String,
+}
+
+impl CurlzTestSuite {
+    pub async fn new() -> Self {
+        dotenv().ok();
+        Self {
+            mock_server: MockServer::start().await,
+            url_part: "/".to_string(),
+            http_method: "GET".to_string(),
+            payload: "# curlz rocks".to_string(),
+        }
+    }
+
+    /// sets the target url to be requested
+    pub fn send_to_path(mut self, url_part: &str) -> Self {
+        self.url_part = url_part.to_string();
+        self
+    }
+
+    /// sets the http method used for the request
+    pub fn send_with_method(mut self, http_method: HttpMethod) -> Self {
+        self.http_method = (&http_method).into();
+        self
+    }
+
+    /// runs curlz and requests the given url
+    pub async fn issue_request(&mut self) -> Assert {
+        self.prepare_mock_server().await;
+
+        let url = format!("{}{}", &self.mock_server.uri(), self.url_part);
+        binary()
+            .arg("r")
+            .args(["-X", self.http_method.as_str()])
+            .arg(url.as_str())
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(&self.payload))
+            .stderr(predicate::str::contains("% Total"))
+    }
+
+    async fn prepare_mock_server(&mut self) {
+        Mock::given(method(self.http_method.as_str()))
+            .and(path(self.url_part.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_string(self.payload.as_str()))
+            .mount(&self.mock_server)
+            .await;
+    }
+}


### PR DESCRIPTION
This PR implements 
- #5
- #12 

done:
- [x] add `HttpVersion` to `HttpRequest`
- [x] add `HttpBody` to `HttpRequest` with string, binary and external file support
- [x] implement http template file body parsing + test
- [x] implement http body to curl parameter mapping