### PR TITLE
feat(http-language): body variable substitution #21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,17 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,15 +432,36 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -666,15 +676,6 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -846,6 +847,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,9 +956,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "minijinja"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8602d7e47eed0a7026af5666ff0d4500548afe1f7567a351ada0bb61bd250a9e"
+checksum = "bfe5cc10c1972e2ccc77fa813aab62c5f2ee0181f659d73e2b33403ab76f4f1e"
 dependencies = [
  "serde",
 ]
@@ -988,7 +1017,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1316,6 +1345,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]
 
 [dependencies]
-env_logger = "0.9"
+env_logger = "0.10"
 log = "0.4"
 clap = { version = "3.2", features = ["derive", "std", "cargo"], default-features = false }
 clap-verbosity-flag = "1.0"
@@ -21,7 +21,7 @@ dialoguer = "0.10"
 filenamify = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
-minijinja = "0.25"
+minijinja = "0.29"
 
 jsonwebtoken = "8.1"
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/README.md
+++ b/README.md
@@ -13,41 +13,30 @@
  
 ## Features
 
-- ☑️.env files
-- ☑️.yaml env files
-- ☑️placeholder evaluation, with the [minijinja](https://docs.rs/minijinja/latest/minijinja/) template engine
+- variables from `.env` and `.yaml` environment files
+- ️placeholder evaluation, with the [minijinja](https://docs.rs/minijinja/latest/minijinja/) template engine
   - in urls
   - in http headers (`-H | --header` arguments)
+  - in the http body (`-d | --data` argument)
   - in every other passed curl parameter
-- ☑️save request as a bookmark, containing
-  - curl arguments
-  - http headers
-  - http method
-  - placeholders
-- ☑️pass all arguments after `--` to curl, that makes drop-in-replacement possible
-- ☑️execute a bookmarked request
-- ☑️special placeholder variables that would interact with the user
-  - ☑️prompt for a password as `{{ prompt_password() }}` 
-    `curlz r https://api.github.com/user -- -u "{{ username }}:{{ prompt_password() }}"`
-  - ☑️prompt for interactive input with a label as `{{ prompt_for("Username") }}` or `{{ prompt_for("Birthdate") }}`
-    `curlz -- -u "{{ prompt_for("Username") }}:{{ prompt_password() }}" https://api.github.com/user`
-- ☑️evaluate placeholders at the beginning of an url like:
-```sh
-curlz r --define 'host=https://httpbin.org' '{{host}}/get?show_env={{ prompt_for("show_env") }}'
-```
-- ☑️special placeholder for developers, like for Json Web Tokens (JWT)
-  example: `{{ jwt(claims, signing_key) }}`, where `claims` and `signing_key` are looked up at the environment file or can be directly provided map and string
-```sh
-curlz r -H 'Authorization: Bearer {{ jwt({"uid": "1234"}, "000") }}' https://httpbin.org/bearer -- -vvv
-```
-- ☑️send a http body via `-d | --data` 
-```sh
-curlz r -d 'Hello World' -X POST 'https://httpbin.org/anything'
-```
-- ☑️send a json payload and headers with the `--json` argument
-```sh
-curlz r --json -d '{ "foo": "bar" }' -X POST 'https://httpbin.org/anything'
-```
+- save request as a bookmark, containing
+  - curl arguments, http headers, http method and placeholders
+- support any curl argument after a `--`, that makes a drop-in-replacemen for curl
+- execute a bookmarked request
+- special placeholders that would interact with the user
+  - prompt for a password as `{{ prompt_password() }}` 
+  `curlz r https://api.github.com/user -- -u "{{ username }}:{{ prompt_password() }}"`
+  - prompt for interactive input with a label as `{{ prompt_for("Username") }}` or `{{ prompt_for("Birthdate") }}`
+  `curlz -- -u "{{ prompt_for("Username") }}:{{ prompt_password() }}" https://api.github.com/user`
+- ️evaluate placeholders at the beginning of an url like:
+`curlz r --define 'host=https://httpbin.org' '{{host}}/get'`
+- ️special placeholder for developers, like for Json Web Tokens (JWT)
+`{{ jwt(claims, signing_key) }}`, where `claims` and `signing_key` are looked up at the environment file or can be directly provided map and string
+`curlz r -H 'Authorization: Bearer {{ jwt({"uid": "1234"}, "000") }}' https://httpbin.org/bearer -- -vvv`
+- send a http body via `-d | --data` 
+`curlz r -d 'Hello World' -X POST https://httpbin.org/anything`
+- send a json payload and headers with the `--json` argument
+`curlz r --json '{ "foo": "bar" }' -X POST 'https://httpbin.org/anything'`
 
 ## WIP
 - [⏳] support rest client template language [see #5](https://github.com/curlz-rs/curlz/issues/5)

--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@
 ## Features
 
 - variables from `.env` and `.yaml` environment files
-- ️placeholder evaluation, with the [minijinja](https://docs.rs/minijinja/latest/minijinja/) template engine
-  - in urls
-  - in http headers (`-H | --header` arguments)
-  - in the http body (`-d | --data` argument)
-  - in every other passed curl parameter
-- save request as a bookmark, containing
-  - curl arguments, http headers, http method and placeholders
-- support any curl argument after a `--`, that makes a drop-in-replacemen for curl
-- execute a bookmarked request
-- special placeholders that would interact with the user
+- ️placeholder evaluation using the [minijinja](https://docs.rs/minijinja/latest/minijinja/) template engine, which can be used in URLs, HTTP headers, the HTTP body, and other passed curl parameters
+- ability to save and execute requests as bookmarks with a shortname
+- support any curl argument after a `--`, that makes a drop-in-replacement for curl
+- special placeholders to interact with the user
   - prompt for a password as `{{ prompt_password() }}` 
   `curlz r https://api.github.com/user -- -u "{{ username }}:{{ prompt_password() }}"`
   - prompt for interactive input with a label as `{{ prompt_for("Username") }}` or `{{ prompt_for("Birthdate") }}`

--- a/src/curlz/data/request/http_body.rs
+++ b/src/curlz/data/request/http_body.rs
@@ -43,3 +43,9 @@ impl HttpBody {
         })
     }
 }
+
+impl From<&str> for HttpBody {
+    fn from(value: &str) -> Self {
+        Self::InlineText(value.to_string())
+    }
+}

--- a/src/curlz/ops/run_curl.rs
+++ b/src/curlz/ops/run_curl.rs
@@ -29,7 +29,7 @@ impl<'a> RunCurlCommand<'a> {
 impl<'a> MutOperation for RunCurlCommand<'a> {
     type Output = ();
 
-    fn execute(&self, context: &mut OperationContext) -> crate::Result<Self::Output> {
+    fn execute(&self, context: &mut OperationContext) -> Result<Self::Output> {
         let mut renderer = context.renderer_with_placeholders(&self.request.placeholders);
 
         let url = renderer.render(self.request.url.as_ref(), "url")?;
@@ -41,12 +41,12 @@ impl<'a> MutOperation for RunCurlCommand<'a> {
         }
         let payload = if self.request.body.ne(&HttpBody::None) {
             vec![
-                "--data",
+                "--data".to_string(),
                 match &self.request.body {
-                    HttpBody::InlineText(s) => s.as_str(),
+                    HttpBody::InlineText(s) => renderer.render(s.as_str(), "body")?,
                     HttpBody::InlineBinary(_) => todo!("inline binary data not impl yet"),
                     HttpBody::Extern(_) => todo!("external file data loading impl yet"),
-                    HttpBody::None => "",
+                    HttpBody::None => "".to_string(),
                 },
             ]
         } else {

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use curlz::data::{HttpBody, HttpMethod};
 use predicates::prelude::*;
+use predicates::str::contains;
 
 use crate::testlib::{binary, CurlzTestSuite};
 
@@ -17,7 +18,6 @@ fn should_show_usage_when_no_args_passed() {
 #[tokio::test]
 async fn should_send_as_get() {
     CurlzTestSuite::new()
-        .await
         .with_path("/gitignore/templates/Rust")
         .send_request()
         .await;
@@ -26,7 +26,6 @@ async fn should_send_as_get() {
 #[tokio::test]
 async fn should_send_as_post() {
     CurlzTestSuite::new()
-        .await
         .with_path("/post")
         .with_method(HttpMethod::Post)
         .send_request()
@@ -36,10 +35,22 @@ async fn should_send_as_post() {
 #[tokio::test]
 async fn should_send_text_as_put() {
     CurlzTestSuite::new()
-        .await
         .with_path("/put")
         .with_method(HttpMethod::Put)
         .with_payload(HttpBody::InlineText("Howdy Pal!".to_string()))
+        .send_request()
+        .await;
+}
+
+#[tokio::test]
+async fn should_send_as_post_with_body_variables() {
+    CurlzTestSuite::new()
+        .with_env_variable("id", "1")
+        .with_env_variable("username", "john")
+        .with_path("/post")
+        .with_method(HttpMethod::Post)
+        .with_payload(r#"{ "id": {{ id }}, "user": "{{ username }}" }"#)
+        .expect_payload(contains(r#"{ "id": 1, "user": "john" }"#))
         .send_request()
         .await;
 }

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -27,7 +27,7 @@ async fn should_send_as_get() {
 async fn should_send_as_post() {
     CurlzTestSuite::new()
         .await
-        .with_path("/anything")
+        .with_path("/post")
         .with_method(HttpMethod::Post)
         .send_request()
         .await;
@@ -37,7 +37,7 @@ async fn should_send_as_post() {
 async fn should_send_text_as_put() {
     CurlzTestSuite::new()
         .await
-        .with_path("/anything")
+        .with_path("/put")
         .with_method(HttpMethod::Put)
         .with_payload(HttpBody::InlineText("Howdy Pal!".to_string()))
         .send_request()

--- a/tests/testlib.rs
+++ b/tests/testlib.rs
@@ -24,8 +24,8 @@ pub struct CurlzTestSuite {
     expected_stdout: BoxPredicate<str>,
 }
 
-impl CurlzTestSuite {
-    pub fn new() -> Self {
+impl Default for CurlzTestSuite {
+    fn default() -> Self {
         dotenv().ok();
         Self {
             url_part: "/".to_string(),
@@ -34,6 +34,12 @@ impl CurlzTestSuite {
             defined_variables: Default::default(),
             expected_stdout: BoxPredicate::new(contains("")),
         }
+    }
+}
+
+impl CurlzTestSuite {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// runs curlz and requests the given url from a local echo http server

--- a/tests/testlib.rs
+++ b/tests/testlib.rs
@@ -1,8 +1,11 @@
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
+use std::collections::HashMap;
+use std::ops::Deref;
 
 use assert_cmd::assert::Assert;
 use dotenvy::dotenv;
+use predicates::str::contains;
+use predicates::{BoxPredicate, Predicate};
 use std::process::Command;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
@@ -14,21 +17,46 @@ pub fn binary() -> Command {
 }
 
 pub struct CurlzTestSuite {
-    mock_server: MockServer,
     url_part: String,
     http_method: String,
     payload: HttpBody,
+    defined_variables: HashMap<String, String>,
+    expected_stdout: BoxPredicate<str>,
 }
 
 impl CurlzTestSuite {
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         dotenv().ok();
         Self {
-            mock_server: MockServer::start().await,
             url_part: "/".to_string(),
             http_method: "GET".to_string(),
             payload: HttpBody::None,
+            defined_variables: Default::default(),
+            expected_stdout: BoxPredicate::new(contains("")),
         }
+    }
+
+    /// runs curlz and requests the given url from a local echo http server
+    pub async fn send_request(mut self) -> Assert {
+        let mock_server = self.prepare_mock_server().await;
+
+        binary()
+            .arg("r")
+            .args(self.args_method())
+            .args(self.args_define())
+            .args(self.args_data())
+            .arg(self.arg_url(&mock_server))
+            .assert()
+            .success()
+            .stdout(self.expected_stdout)
+            .stderr(contains("% Total"))
+    }
+
+    /// prepares a variable that ends as a `--define name=value` cli argument
+    pub fn with_env_variable(mut self, name: &str, value: &str) -> Self {
+        self.defined_variables
+            .insert(name.to_string(), value.to_string());
+        self
     }
 
     /// sets the target url to be requested
@@ -44,42 +72,64 @@ impl CurlzTestSuite {
     }
 
     /// sets the http body payload that is send
-    pub fn with_payload(mut self, body: HttpBody) -> Self {
-        self.payload = body;
+    /// also readjusts the expected output based on the given payload
+    pub fn with_payload(mut self, body: impl Into<HttpBody>) -> Self {
+        self.payload = body.into();
+        let predicate = {
+            let pattern = String::from_utf8_lossy(self.payload.as_bytes().unwrap());
+            contains(pattern.deref())
+        };
+
+        self.expect_payload(predicate)
+    }
+
+    /// sets the expected output
+    pub fn expect_payload<P: Predicate<str>>(mut self, predicate: P) -> Self
+    where
+        P: Send + Sync + 'static,
+    {
+        self.expected_stdout = BoxPredicate::new(predicate);
         self
     }
 
-    /// runs curlz and requests the given url from a local echo http server
-    pub async fn send_request(&mut self) -> Assert {
-        self.prepare_mock_server().await;
-
-        let url = format!("{}{}", &self.mock_server.uri(), self.url_part);
-        // todo: if body is binary, this will not work, better not have expectations for binary payloads
-        let expected_stdout =
-            predicate::str::contains(String::from_utf8_lossy(self.payload.as_bytes().unwrap()));
-        let data = match &self.payload {
-            HttpBody::None => vec![],
-            HttpBody::InlineText(s) => vec!["-d", s.as_str()],
-            _ => todo!(),
-        };
-
-        binary()
-            .arg("r")
-            .args(["-X", self.http_method.as_str()])
-            .args(data)
-            .arg(url.as_str())
-            .assert()
-            .success()
-            .stdout(expected_stdout)
-            .stderr(predicate::str::contains("% Total"))
+    fn args_method(&self) -> [&str; 2] {
+        ["-X", self.http_method.as_str()]
     }
 
-    async fn prepare_mock_server(&mut self) {
+    fn arg_url(&self, mock_server: &MockServer) -> String {
+        format!("{}{}", mock_server.uri(), self.url_part)
+    }
+
+    fn args_data(&self) -> Vec<&str> {
+        match &self.payload {
+            HttpBody::None => vec![],
+            HttpBody::InlineText(s) => vec!["-d", s.as_str()],
+            HttpBody::InlineBinary(_) => {
+                todo!("binary data are not yet supported for the http body")
+            }
+            HttpBody::Extern(_) => {
+                todo!("external file references are not yet supported for the http body")
+            }
+        }
+    }
+
+    fn args_define(&self) -> Vec<String> {
+        self.defined_variables
+            .iter()
+            .flat_map(|(name, value)| vec!["--define".to_string(), format!("{name}={value}")])
+            .collect::<Vec<_>>()
+    }
+
+    async fn prepare_mock_server(&mut self) -> MockServer {
+        let mock_server = MockServer::start().await;
+
         Mock::given(method(self.http_method.as_str()))
             .and(path(self.url_part.as_str()))
             .respond_with(EchoResponder::default())
-            .mount(&self.mock_server)
+            .mount(&mock_server)
             .await;
+
+        mock_server
     }
 }
 


### PR DESCRIPTION
- closes #21 
- introduce echo server behaviour to the testlib, to verify the variable substitution on the body
- implement test case with payload that contains placeholders
- implement variable substitution on the body
- bump `env_logger` and `minijinja` versions
