### PR TITLE
chore: release `0.1.0-alpha.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.5](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.4...v0.1.0-alpha.5) - 2023-02-28
+
+### Added
+- *(template)* support environment variables from process / shell (#30) (#31)

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.4 -> 0.1.0-alpha.5 (⚠️ API breaking changes)

### ⚠️ `curlz` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/enum_missing.ron

Failed in:
  enum curlz::data::HttpVersion, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/request/http_version.rs:7
  enum curlz::cli::Commands, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/commands/mod.rs:10
  enum curlz::cli::commands::Commands, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/commands/mod.rs:10
  enum curlz::ops::Verbosity, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/mod.rs:15
  enum curlz::data::HttpMethod, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/request/http_method.rs:7
  enum curlz::cli::commands::BookmarkCommands, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/commands/bookmark.rs:12
  enum curlz::data::HttpBody, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/request/http_body.rs:6

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/function_missing.ron

Failed in:
  function curlz::interactive::user_question, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/interactive.rs:5
  function curlz::cli::main::exec, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/main.rs:10

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/struct_missing.ron

Failed in:
  struct curlz::data::HttpHeaders, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/request/http_headers.rs:5
  struct curlz::ops::LoadBookmark, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/load_bookmark.rs:6
  struct curlz::ops::OperationContext, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/mod.rs:34
  struct curlz::workspace::DotEnvFile, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/workspace/environment/dot_env.rs:6
  struct curlz::cli::Cli, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/mod.rs:15
  struct curlz::data::Bookmark, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/bookmark.rs:7
  struct curlz::ops::SaveBookmark, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/save_bookmark.rs:7
  struct curlz::data::HttpRequest, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/request/http_request.rs:7
  struct curlz::workspace::YamlEnvFile, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/workspace/environment/yaml_env.rs:7
  struct curlz::cli::commands::RequestCli, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/commands/request.rs:20
  struct curlz::data::HttpUri, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/data/request/http_uri.rs:10
  struct curlz::variables::Placeholder, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/variables.rs:4
  struct curlz::workspace::Environment, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/workspace/environment/env.rs:8
  struct curlz::cli::commands::BookmarkCli, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/cli/commands/bookmark.rs:6
  struct curlz::ops::RunCurlCommand, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/run_curl.rs:19
  struct curlz::workspace::BookmarkCollection, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/workspace/bookmark_collection.rs:13

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/trait_missing.ron

Failed in:
  trait curlz::ops::IntoCurlArguments, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/run_curl.rs:11
  trait curlz::ops::MutOperation, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/mod.rs:27
  trait curlz::ops::Operation, previously in file /tmp/.tmplvoNMm/curlz/src/curlz/ops/mod.rs:21
```

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).