### PR TITLE
chore: release 0.1.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.6](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.5...v0.1.0-alpha.6) - 2023-03-02
+
+### Added
+- *(template)* implement the basic auth template function (#7) (#33)
+- *(template)* support environment variables from process / shell (#30) (#31)
+
+### Other
+- release `0.1.0-alpha.5` (#29)
+
 ## [0.1.0-alpha.5](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.4...v0.1.0-alpha.5) - 2023-02-28
 
 ### Added

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.5 -> 0.1.0-alpha.6 (✓ API compatible changes)

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).