### PR TITLE
chore: release 0.1.0-alpha.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.9](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.8...v0.1.0-alpha.9) - 2023-03-05
+
+### Added
+- *(cli)* implement `-u | --user` request cli argument (#7) (#46)
+- *(template)* implement the basic auth template function (#7) (#33)
+- *(template)* support environment variables from process / shell (#30) (#31)
+
+### Other
+- release (#43)
+- release (#39)
+- release 0.1.0-alpha.6 (#34)
+- release `0.1.0-alpha.5` (#29)
+
 ## [0.1.0-alpha.8](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.7...v0.1.0-alpha.8) - 2023-03-05
 
 ### Added

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.8 -> 0.1.0-alpha.9 (⚠️ API breaking changes)

### ⚠️ `curlz` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RequestCli.user in /tmp/.tmplKHHOM/curlz/curlz/src/curlz/cli/sub_commands/request.rs:76
  field RequestCli.user in /tmp/.tmplKHHOM/curlz/curlz/src/curlz/cli/sub_commands/request.rs:76
```

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).