### PR TITLE
chore: release v0.1.0-alpha.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.10](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.9...v0.1.0-alpha.10) - 2023-03-14
+
+### Added
+- *(cli)* implement `-u | --user` request cli argument (#7) (#46)
+- *(template)* implement the basic auth template function (#7) (#33)
+- *(template)* support environment variables from process / shell (#30) (#31)
+
+### Fixed
+- *(http-lang)* make grammar bit more robust for trailing whitespaces (#63)
+
+### Other
+- migrate to clap v4 (#54)
+- *(deps)* bump pest from 2.5.5 to 2.5.6 (#51)
+- release 0.1.0-alpha.9 (#45)
+- release (#43)
+- release (#39)
+- release 0.1.0-alpha.6 (#34)
+- release `0.1.0-alpha.5` (#29)
+
 ## [0.1.0-alpha.9](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.8...v0.1.0-alpha.9) - 2023-03-05
 
 ### Added

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.9 -> 0.1.0-alpha.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.10](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.9...v0.1.0-alpha.10) - 2023-03-14

### Added
- *(cli)* implement `-u | --user` request cli argument (#7) (#46)
- *(template)* implement the basic auth template function (#7) (#33)
- *(template)* support environment variables from process / shell (#30) (#31)

### Fixed
- *(http-lang)* make grammar bit more robust for trailing whitespaces (#63)

### Other
- migrate to clap v4 (#54)
- *(deps)* bump pest from 2.5.5 to 2.5.6 (#51)
- release 0.1.0-alpha.9 (#45)
- release (#43)
- release (#39)
- release 0.1.0-alpha.6 (#34)
- release `0.1.0-alpha.5` (#29)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).