### PR TITLE
chore: release v0.1.0-alpha.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates",
+ "predicates 2.1.5",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -315,7 +315,7 @@ dependencies = [
  "minijinja-stack-ref",
  "pest",
  "pest_derive",
- "predicates",
+ "predicates 3.0.1",
  "pretty_assertions",
  "rstest",
  "serde",
@@ -1156,6 +1156,18 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba7d6ead3e3966038f68caa9fc1f860185d95a793180bbcfe0d0da47b3961ed"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
 
 [[package]]
 name = "predicates"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 2.1.5",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -315,7 +315,7 @@ dependencies = [
  "minijinja-stack-ref",
  "pest",
  "pest_derive",
- "predicates 3.0.1",
+ "predicates",
  "pretty_assertions",
  "rstest",
  "serde",
@@ -1156,18 +1156,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba7d6ead3e3966038f68caa9fc1f860185d95a793180bbcfe0d0da47b3961ed"
-dependencies = [
- "anstyle",
- "difflib",
- "itertools",
- "predicates-core",
-]
 
 [[package]]
 name = "predicates"

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.11](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.10...v0.1.0-alpha.11) - 2023-03-15
+
+### Fixed
+- *(deps)* update rust crate jsonwebtoken to 8.3 (#73)
+- *(deps)* update rust crate jsonwebtoken to 8.2 (#66)
+- *(deps)* update rust crate pest_derive to 2.5 (#68)
+
+### Other
+- *(deps)* update rust crate predicates to v3 (#72)
+- *(deps)* update rust crate tempfile to 3.4 (#65)
+- release v0.1.0-alpha.10 (#53)
+
 ## [0.1.0-alpha.10](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.9...v0.1.0-alpha.10) - 2023-03-14
 
 ### Added

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.10 -> 0.1.0-alpha.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.11](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.10...v0.1.0-alpha.11) - 2023-03-15

### Fixed
- *(deps)* update rust crate jsonwebtoken to 8.3 (#73)
- *(deps)* update rust crate jsonwebtoken to 8.2 (#66)
- *(deps)* update rust crate pest_derive to 2.5 (#68)

### Other
- *(deps)* update rust crate predicates to v3 (#72)
- *(deps)* update rust crate tempfile to 3.4 (#65)
- release v0.1.0-alpha.10 (#53)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).