### PR TITLE
chore: release v0.1.0-alpha.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -6,6 +6,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.12](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.11...v0.1.0-alpha.12) - 2023-03-24
+
+### Added
+- robuster jwt token generation (#87)
+- *(cli)* implement `-u | --user` request cli argument (#7) (#46)
+- *(template)* implement the basic auth template function (#7) (#33)
+- *(template)* support environment variables from process / shell (#30) (#31)
+
+### Fixed
+- *(http-lang)* make grammar bit more robust (#82)
+- *(deps)* update rust crate jsonwebtoken to 8.3 (#73)
+- *(deps)* update rust crate jsonwebtoken to 8.2 (#66)
+- *(deps)* update rust crate pest_derive to 2.5 (#68)
+- *(http-lang)* make grammar bit more robust for trailing whitespaces (#63)
+
+### Other
+- *(deps)* update rust crate rstest to 0.17 (#84)
+- release v0.1.0-alpha.11 (#71)
+- *(deps)* update rust crate predicates to v3 (#72)
+- *(deps)* update rust crate tempfile to 3.4 (#65)
+- release v0.1.0-alpha.10 (#53)
+- migrate to clap v4 (#54)
+- *(deps)* bump pest from 2.5.5 to 2.5.6 (#51)
+- release 0.1.0-alpha.9 (#45)
+- release (#43)
+- release (#39)
+- release 0.1.0-alpha.6 (#34)
+- release `0.1.0-alpha.5` (#29)
+
 ## [0.1.0-alpha.11](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.10...v0.1.0-alpha.11) - 2023-03-15
 
 ### Fixed

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.11 -> 0.1.0-alpha.12 (⚠️ API breaking changes)

### ⚠️ `curlz` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/enum_variant_missing.ron

Failed in:
  variant Rule::whitespace, previously in file /tmp/.tmpOTIx7S/curlz/src/curlz/domain/http_lang/parse_request.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.12](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.11...v0.1.0-alpha.12) - 2023-03-24

### Added
- robuster jwt token generation (#87)
- *(cli)* implement `-u | --user` request cli argument (#7) (#46)
- *(template)* implement the basic auth template function (#7) (#33)
- *(template)* support environment variables from process / shell (#30) (#31)

### Fixed
- *(http-lang)* make grammar bit more robust (#82)
- *(deps)* update rust crate jsonwebtoken to 8.3 (#73)
- *(deps)* update rust crate jsonwebtoken to 8.2 (#66)
- *(deps)* update rust crate pest_derive to 2.5 (#68)
- *(http-lang)* make grammar bit more robust for trailing whitespaces (#63)

### Other
- *(deps)* update rust crate rstest to 0.17 (#84)
- release v0.1.0-alpha.11 (#71)
- *(deps)* update rust crate predicates to v3 (#72)
- *(deps)* update rust crate tempfile to 3.4 (#65)
- release v0.1.0-alpha.10 (#53)
- migrate to clap v4 (#54)
- *(deps)* bump pest from 2.5.5 to 2.5.6 (#51)
- release 0.1.0-alpha.9 (#45)
- release (#43)
- release (#39)
- release 0.1.0-alpha.6 (#34)
- release `0.1.0-alpha.5` (#29)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).