### PR TITLE
feat(docker): package curlz as docker image that can be used in CI (#86) (#94

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM curlimages/curl:8.00.1 as builder
 
+LABEL org.opencontainers.image.source https://github.com/curlz-rs/curlz
 ARG CURLZ_RELEASE_TAG=v0.1.0-alpha.11
 ARG CURLZ_GIT_REPO=https://github.com/curlz-rs/curlz
 ARG LABEL_VERSION=1.0.0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,7 +18,6 @@ build:
 
 multibuild:
 	docker buildx build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "ghcr.io/curlz-rs/curlz:${LATEST_RELEASE_VERSION}" --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
-	docker buildx imagetools create "ghcr.io/curlz-rs/curlz:${LATEST_RELEASE_VERSION}" --tag curlz-rs/curlz:latest
 
 publish:
 	docker push ghcr.io/curlz-rs/curlz:${LATEST_RELEASE_VERSION}


### PR DESCRIPTION
- connecting the repo to the [package repo](https://github.com/orgs/curlz-rs/packages/container/package/curlz)