### PR TITLE
chore: release v0.1.0-alpha.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "curlz"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -980,18 +980,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "minijinja"
-version = "0.30.7"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819be6b8bd3236f0fdbf86b1ff2d1f42ef8ef939eed74f6bc3ecf2e6344cd96"
+checksum = "673d1ece89f7e166f43270800d78f9b1a9d21fda92dbcfa3b98b21213cdccbbc"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "minijinja-stack-ref"
-version = "0.30.7"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab6da6448d26e30a60500cbdb566251d9ce4b50f98ee55bfddb1c6840e336cd"
+checksum = "83672613fd4b90592256553a07e8ae8db7babbbaafe9065437a5797a8f3813b7"
 dependencies = [
  "minijinja",
 ]

--- a/curlz/CHANGELOG.md
+++ b/curlz/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.13](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.12...v0.1.0-alpha.13) - 2023-03-28
+
+### Added
+- *(functions)* implement #98 a build-in function for generating an unix timestamp (#99)
+
+### Fixed
+- *(deps)* update bump minor versions to 0.31 (minor) (#102)
+
+### Other
+- bit more test coverage (#100)
+- release v0.1.0-alpha.12 (#76)
+
 ## [0.1.0-alpha.12](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.11...v0.1.0-alpha.12) - 2023-03-24
 
 ### Added

--- a/curlz/Cargo.toml
+++ b/curlz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "curlz"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 description = "curl wrapper with placeholder, bookmark and environment powers just like postman"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.13"
 edition = "2021"
 license = "GPL-3.0-only"
 include = ["src/**/*", "LICENSE", "*.md"]


### PR DESCRIPTION
## 🤖 New release
* `curlz`: 0.1.0-alpha.12 -> 0.1.0-alpha.13 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.13](https://github.com/curlz-rs/curlz/compare/v0.1.0-alpha.12...v0.1.0-alpha.13) - 2023-03-28

### Added
- *(functions)* implement #98 a build-in function for generating an unix timestamp (#99)

### Fixed
- *(deps)* update bump minor versions to 0.31 (minor) (#102)

### Other
- bit more test coverage (#100)
- release v0.1.0-alpha.12 (#76)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).